### PR TITLE
Allow start time of new log to have the same end time as a past log

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -46,7 +46,7 @@ class Log < ApplicationRecord
 
   def overlapping_user_logs
     return unless start_at && end_at && user
-    overlapping_log = user.logs.where.not(id: self.id).within(start_at, end_at).first
+    overlapping_log = user.logs.where.not(id: self.id).within((start_at + 1.minute), end_at).first
 
     if overlapping_log.present?
       sdate = overlapping_log.start_at.in_time_zone(TIMEZONE).strftime("%m/%d/%Y %I:%M %p")

--- a/make-pr-from-issue.rb
+++ b/make-pr-from-issue.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require 'io/console'
+
+gh_user = ENV['GH_USER']
+if gh_user.nil?
+  print "What's your github username: "
+  gh_user = gets.chomp
+else
+  puts "Logging in as: #{gh_user}"
+end
+
+ORG = 'EnVisageConsulting'
+REPO = 'timelog'
+
+puts  "Converting a GitHub issue to a pull request for #{ORG}/#{REPO}"
+print "What issue number: "
+issue_num = gets.chomp
+
+print "What branch to start from (master or development, maybe?): "
+start_branch = gets.chomp
+
+print "What branch to pull from (must be pushed already): "
+end_branch = gets.chomp
+
+print "Enter GitHub password: "
+userpass = STDIN.noecho(&:gets).chomp
+
+command = %Q(curl --user "#{gh_user}:#{userpass}" --silent --request POST --data '{"issue": #{issue_num}, "head": "#{ORG}:#{end_branch}", "base": "#{start_branch}"}' https://api.github.com/repos/#{ORG}/#{REPO}/pulls)
+
+puts command
+puts `#{command}`


### PR DESCRIPTION
Often, the start time for a new log will be the end time of the last log. So we need to allow this. Right now it throws a validation.

E.g. log 1 ended at 11:03 a.m. then log 2 started at 11:03 a.m.

