### PR TITLE
Allow overlapping at end of new log

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -46,7 +46,7 @@ class Log < ApplicationRecord
 
   def overlapping_user_logs
     return unless start_at && end_at && user
-    overlapping_log = user.logs.where.not(id: self.id).within((start_at + 1.minute), end_at).first
+    overlapping_log = user.logs.where.not(id: self.id).within((start_at + 1.minute), (end_at - 1.minute)).first
 
     if overlapping_log.present?
       sdate = overlapping_log.start_at.in_time_zone(TIMEZONE).strftime("%m/%d/%Y %I:%M %p")


### PR DESCRIPTION
Similar to #6, but with end time. If you go retroactively put in time, the end time of the log you're creating cannot be the same as the start time of another. Start time is okay.

Example: If I had an existing log from 2-3, then wanted to go back in and put in my time from earlier (1-2), I would trigger a validation error, because the end time overlaps the existing log.