### PR TITLE
Improve user log reports

### DIFF
--- a/app/assets/stylesheets/application-all.scss
+++ b/app/assets/stylesheets/application-all.scss
@@ -50,3 +50,6 @@
     margin-right: 0.5rem;
   }
 }
+
+.select2-search__field { height: 20px;}
+.select2-search { height: 30px; }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,6 +50,19 @@ class UsersController < ApplicationController
     end
 
     def user_logs
+      filter_by_date
+      filter_by_project
+      @user_logs.order("start_at DESC")
+    end
+
+    def filter_by_project
+      return unless params[:project_ids].present?
+
+      project_ids = params[:project_ids].map{|p| p.to_i}
+      @user_logs = @user_logs.joins(:project_logs).where(project_logs: {project_id: project_ids})
+    end
+
+    def filter_by_date
       start_date = DateTime.strptime(params[:start_date], '%m/%d/%Y').beginning_of_day if params[:start_date].present?
       end_date = DateTime.strptime(params[:end_date], '%m/%d/%Y').end_of_day if params[:end_date].present?
       if start_date.present? && end_date.present?
@@ -61,12 +74,11 @@ class UsersController < ApplicationController
       else
         @user_logs ||= @user.logs.active.latest
       end
-      @user_logs.order("start_at DESC")
     end
 
     def set_per_page
-      # return @per_page = 3 # uncomment for testing with smaller groups
-      @per_page = Kaminari.config.default_per_page
+      return @per_page = 3 # uncomment for testing with smaller groups
+      # @per_page = Kaminari.config.default_per_page
     end
 
     def page_from_date(date)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -80,21 +80,4 @@ class UsersController < ApplicationController
       # return @per_page = 3 # uncomment for testing with smaller groups
       @per_page = Kaminari.config.default_per_page
     end
-
-    def page_from_date(date)
-      records_from_date = user_logs.where('start_at >= ?', date).count.to_f
-
-      ( records_from_date / @per_page ).ceil
-    end
-
-    def pagination_page
-      if params[:date].is_a?(String) && params[:date].match(DATE_PATTERN)
-        date = DateTimeParser.string_to_datetime(params[:date])
-
-        # jump to page using supplied date
-        return page_from_date(date)
-      end
-
-      params[:page]
-    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -77,8 +77,8 @@ class UsersController < ApplicationController
     end
 
     def set_per_page
-      return @per_page = 3 # uncomment for testing with smaller groups
-      # @per_page = Kaminari.config.default_per_page
+      # return @per_page = 3 # uncomment for testing with smaller groups
+      @per_page = Kaminari.config.default_per_page
     end
 
     def page_from_date(date)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,10 +67,12 @@ module ApplicationHelper
     end
   end
 
-  def duration start_at, end_at
+  def duration start_at, end_at, hours=false
     diff = end_at - start_at
 
-    if diff < 1.minute
+    if hours
+      strip_insignificant_zeros(Seconds.to_hrs(diff)).to_i
+    elsif diff < 1.minute
       return "#{strip_insignificant_zeros(diff)} seconds"
     elsif diff < 1.hour
       return "#{strip_insignificant_zeros(Seconds.to_mins(diff))} minutes"

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,4 +2,8 @@ module UsersHelper
   def user_list
     viewing_deactivated? ? @users.deactivated : @users.undeactivated
   end
+
+  def project_in_user_log?(project_ids, project_log)
+    project_ids.present? && project_ids.include?(project_log.project_id.to_s)
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -52,6 +52,8 @@
         <tr>
           <th></th>
           <th class="text-left">Log Date</th>
+          <th class="text-left">Start Time</th>
+          <th class="text-left">End Time</th>
           <th class="text-right">Duration</th>
           <th class="text-center">Edit</th>
         </tr>
@@ -64,6 +66,8 @@
                 <small><%= log_days_of_week(log) %></small>
               </td>
               <td class="text-left"><%= link_to log_title(log), log %></td>
+              <td class="text-left"><%= log.start_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
+              <td class="text-left"><%= log.end_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
               <td class="text-right"><%= duration log.start_at, log.end_at %></td>
               <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
             </tr>

--- a/app/views/reports/invoice_reports/index.html.erb
+++ b/app/views/reports/invoice_reports/index.html.erb
@@ -13,17 +13,17 @@
 
   <div class="row">
     <div class="columns medium-4">
-      <%= f.label :project_ids %>
+      <%= f.label :project_ids, "Projects" %>
       <%= f.collection_select :project_ids, Project.active, :id, :name, {}, {multiple: true, class: "multiselect"} %>
     </div>
 
     <div class="columns medium-3 small-6">
-      <%= f.label :start_date %>
+      <%= f.label :start_date, "Start Date" %>
       <%= f.text_field :start_date, class: 'date' %>
     </div>
 
     <div class="columns medium-3 small-6">
-      <%= f.label :end_date %>
+      <%= f.label :end_date, "End Date" %>
       <%= f.text_field :end_date, class: 'date' %>
     </div>
 

--- a/app/views/reports/invoice_reports/new.html.erb
+++ b/app/views/reports/invoice_reports/new.html.erb
@@ -12,18 +12,18 @@
 
   <div class="row">
     <div class="columns">
-      <%= f.label :project_ids %>
+      <%= f.label :project_ids, "Projects" %>
       <%= f.collection_select :project_ids, Project.active, :id, :name, {}, {multiple: true, class: "multiselect"} %>
     </div>
   </div>
 
   <div class="row">
     <div class="columns small-6">
-      <%= f.label :start_date %>
+      <%= f.label :start_date, "Start Date" %>
       <%= f.text_field :start_date, class: 'date' %>
     </div>
     <div class="columns small-6">
-      <%= f.label :end_date %>
+      <%= f.label :end_date, "End Date" %>
       <%= f.text_field :end_date, class: 'date' %>
     </div>
   </div>

--- a/app/views/reports/payroll_reports/index.html.erb
+++ b/app/views/reports/payroll_reports/index.html.erb
@@ -11,16 +11,16 @@
 <%= form_for @payroll_report, url: reports_payroll_reports_path(@payroll_report), html: { class: 'filters-form' } do |f| %>
   <div class="row">
     <div class="columns medium-4">
-      <%= f.label :user_ids, "Employee" %>
+      <%= f.label :user_ids, "Employees" %>
       <%= f.collection_select :user_ids, User.activated, :id, :name, {}, {multiple: true, class: "multiselect"} %>
     </div>
 
     <div class="columns medium-3 small-6">
-      <%= f.label :start_date %>
+      <%= f.label :start_date, "Start Date" %>
       <%= f.text_field :start_date, class: 'date' %>
     </div>
     <div class="columns medium-3 small-6">
-      <%= f.label :end_date %>
+      <%= f.label :end_date, "End Date" %>
       <%= f.text_field :end_date, class: 'date' %>
     </div>
 

--- a/app/views/reports/payroll_reports/new.html.erb
+++ b/app/views/reports/payroll_reports/new.html.erb
@@ -12,7 +12,7 @@
 
   <div class="row">
     <div class="columns">
-      <%= f.label :user_ids %>
+      <%= f.label :user_ids, "Employees" %>
       <%= f.collection_select :user_ids, User.activated, :id, :name, {}, {multiple: true, class: "multiselect"} %>
       <a onclick='return selectAll()' id="select-all">Select All</a>
     </div>
@@ -20,11 +20,11 @@
 
   <div class="row">
     <div class="columns small-6">
-      <%= f.label :start_date %>
+      <%= f.label :start_date, "Start Date" %>
       <%= f.text_field :start_date, class: 'date' %>
     </div>
     <div class="columns small-6">
-      <%= f.label :end_date %>
+      <%= f.label :end_date, "End Date" %>
       <%= f.text_field :end_date, class: 'date' %>
     </div>
   </div>

--- a/app/views/users/_project_log_table.html.erb
+++ b/app/views/users/_project_log_table.html.erb
@@ -1,0 +1,41 @@
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th class="text-left">Log Date</th>
+      <th class="text-left">Project</th>
+      <th class="text-right">Duration</th>
+      <th class="text-center">Edit</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% if logs.present? %>
+      <% total_time = @user_logs.flat_map(&:project_logs).map{|pl| project_in_user_log?(project_ids, pl) ? pl.hours : 0}.inject(:+) %>
+      <% logs.each do |log| %>
+        <% log.project_logs.each do |project_log| %>
+          <% next unless project_in_user_log?(project_ids, project_log) %>
+          <tr>
+            <td class="text-right">
+              <small><%= log_days_of_week(log) %></small>
+            </td>
+            <td class="text-left"><%= link_to log_title(log), log %></td>
+            <td class="text-left"><%= project_log.project.name %></td>
+            <td class="text-right"><%= project_log.hours.to_s + " hours" %></td>
+            <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
+          </tr>
+        <% end %>
+      <% end %>
+    <% else %>
+      <tr>
+        <td class="empty" colspan="5">No logs found</td>
+      </tr>
+    <% end %>
+  </tbody>
+  <tfoot style="background: #fff; border: 0">
+    <tr>
+      <td class="text-right stat" colspan="3">Total:</td>
+      <td class="text-right stat" colspan="1"><%= total_time %></td>
+      <td></td>
+    </tr>
+  </tfoot>
+</table>

--- a/app/views/users/_user_log_table.html.erb
+++ b/app/views/users/_user_log_table.html.erb
@@ -1,0 +1,32 @@
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th class="text-left">Log Date</th>
+      <th class="text-left">Start Time</th>
+      <th class="text-left">End Time</th>
+      <th class="text-right">Duration</th>
+      <th class="text-center">Edit</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% if logs.present? %>
+      <% logs.each do |log| %>
+        <tr>
+          <td class="text-right">
+            <small><%= log_days_of_week(log) %></small>
+          </td>
+          <td class="text-left"><%= link_to log_title(log), log %></td>
+          <td class="text-left"><%= log.start_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
+          <td class="text-left"><%= log.end_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
+          <td class="text-right"><%= duration log.start_at, log.end_at %></td>
+          <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
+        </tr>
+      <% end %>
+    <% else %>
+      <tr>
+        <td class="empty" colspan="6">No logs found</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,7 @@
 <% if current_user != @user %>
   <%= back_link "Return to User List", users_path %>
 <% end %>
+<%= back_link "Return to Dashboard", root_path %>
 
 <div class="row">
   <div class="columns">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,18 +5,33 @@
 <div class="row">
   <div class="columns">
     <div class="spacer"></div>
-    <% if @logs.total_count > @per_page %>
-      <div class="float-right">
-        <%= form_tag @user, method: :get do %>
-          <div class="input-group no-margin">
-            <%= text_field_tag :date, params[:date] || Date.today.strftime(DATE_STRFTIME), class: "input-group-field date" %>
-            <div class="input-group-button">
-              <%= submit_tag "Jump to Date", class: 'button' %>
-            </div>
+    <div id="user-log-filter">
+      <%= form_tag @user, method: :get do %>
+        <div class="row">
+          <div class="columns medium-4">
+            <%= label_tag :project_ids %>
+            <%= select_tag :project_ids, options_from_collection_for_select(Project.active, :id, :name), {multiple: true, class: "multiselect"} %>
           </div>
-        <% end %>
-      </div>
-    <% end %>
+          <div class="columns medium-3 small-6">
+            <%= label_tag :start_date %>
+            <%= text_field_tag :start_date, params[:start_date], class: 'date' %>
+          </div>
+          <div class="columns medium-3 small-6">
+            <%= label_tag :end_date %>
+            <%= text_field_tag :end_date, params[:end_date], class: 'date' %>
+          </div>
+          <div class="columns medium-2 small-6">
+            <%= label_tag "", "&nbsp;".html_safe %>
+            <%= submit_tag "Filter", class: 'button expanded' %>
+          </div>
+          <div class="columns medium-2 small-6">
+            <%= label_tag "", "&nbsp;".html_safe %>
+            <%= submit_tag "Clear Filters", class: 'button expanded' %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
     <h3><%= @user.name %>'s Logs</h3>
     <table>
       <thead>
@@ -45,7 +60,7 @@
           <% end %>
         <% else %>
           <tr>
-            <td class="empty" colspan="3">You have no logs yet</td>
+            <td class="empty" colspan="6">No logs found</td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,28 +9,25 @@
       <%= form_tag @user, method: :get do %>
         <div class="row">
           <div class="columns medium-4">
-            <%= label_tag :project_ids %>
+            <%= label_tag :project_ids, "Projects" %>
             <%= select_tag :project_ids, options_from_collection_for_select(Project.active, :id, :name), {multiple: true, class: "multiselect"} %>
           </div>
           <div class="columns medium-3 small-6">
-            <%= label_tag :start_date %>
+            <%= label_tag :start_date, "Start Date" %>
             <%= text_field_tag :start_date, params[:start_date], class: 'date' %>
           </div>
           <div class="columns medium-3 small-6">
-            <%= label_tag :end_date %>
+            <%= label_tag :end_date, "End Date" %>
             <%= text_field_tag :end_date, params[:end_date], class: 'date' %>
           </div>
           <div class="columns medium-2 small-6">
             <%= label_tag "", "&nbsp;".html_safe %>
             <%= submit_tag "Filter", class: 'button expanded' %>
           </div>
-          <div class="columns medium-2 small-6">
-            <%= label_tag "", "&nbsp;".html_safe %>
-            <%= submit_tag "Clear Filters", class: 'button expanded' %>
-          </div>
         </div>
       <% end %>
     </div>
+    <div class="spacer"></div>
 
     <h3><%= @user.name %>'s Logs</h3>
     <table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,79 +31,11 @@
 
     <h3><%= @user.name %>'s Logs</h3>
     <% project_ids = params[:project_ids] %>
-    <table>
-      <thead>
-        <tr>
-          <th></th>
-          <th class="text-left">Log Date</th>
-          <% if project_ids.present? %>
-            <th class="text-left">Project</th>
-          <% else %>
-            <th class="text-left">Start Time</th>
-            <th class="text-left">End Time</th>
-          <% end %>
-          <th class="text-right">Duration</th>
-          <th class="text-center">Edit</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% if @logs.present? %>
-          <% total_page_time = 0 %>
-          <% total_time = @user_logs.flat_map(&:project_logs).map{|pl| project_in_user_log?(project_ids, pl) ? pl.hours : 0}.inject(:+) %>
-          <% @logs.each do |log| %>
-            <% if project_ids.present? %>
-              <% log.project_logs.each do |project_log| %>
-                <% next unless project_in_user_log?(project_ids, project_log) %>
-                <tr>
-                  <td class="text-right">
-                    <small><%= log_days_of_week(log) %></small>
-                  </td>
-                  <td class="text-left"><%= link_to log_title(log), log %></td>
-                  <td class="text-left"><%= project_log.project.name %></td>
-                  <td class="text-right"><%= project_log.hours + "Hours" %></td>
-                  <% total_page_time += project_log.hours %>
-                  <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
-                </tr>
-              <% end %>
-            <% else %>
-              <tr>
-                <td class="text-right">
-                  <small><%= log_days_of_week(log) %></small>
-                </td>
-                <td class="text-left"><%= link_to log_title(log), log %></td>
-                <td class="text-left"><%= log.start_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
-                <td class="text-left"><%= log.end_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
-                <td class="text-right"><%= duration log.start_at, log.end_at %></td>
-                <% total_page_time += duration log.start_at, log.end_at, true %>
-                <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
-              </tr>
-            <% end %>
-          <% end %>
-        <% else %>
-          <tr>
-            <% if project_ids.present? %>
-              <td class="empty" colspan="5">No logs found</td>
-            <% else %>
-              <td class="empty" colspan="6">No logs found</td>
-            <% end %>
-          </tr>
-        <% end %>
-      </tbody>
-      <% if project_ids.present? %>
-        <tfoot>
-          <tr>
-            <td class="text-right" colspan="3">Page Total:</td>
-            <td class="text-right" colspan="1"><%= total_page_time %></td>
-            <td></td>
-          </tr>
-          <tr>
-            <td class="text-right stat" colspan="3">Total:</td>
-            <td class="text-right stat" colspan="1"><%= total_time %></td>
-            <td></td>
-          </tr>
-        </tfoot>
-      <% end %>
-    </table>
+    <% if project_ids.present? %>
+      <%= render "project_log_table", logs: @logs, user_logs: @user_logs, project_ids: project_ids %>
+    <% else %>
+      <%= render "user_log_table", logs: @logs %>
+    <% end %>
     <%= paginate(@logs, {params: {date: nil}}) if @logs.present? %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,6 +23,8 @@
         <tr>
           <th></th>
           <th class="text-left">Log Date</th>
+          <th class="text-left">Start Time</th>
+          <th class="text-left">End Time</th>
           <th class="text-right">Duration</th>
           <th class="text-center">Edit</th>
         </tr>
@@ -35,6 +37,8 @@
                 <small><%= log_days_of_week(log) %></small>
               </td>
               <td class="text-left"><%= link_to log_title(log), log %></td>
+              <td class="text-left"><%= log.start_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
+              <td class="text-left"><%= log.end_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
               <td class="text-right"><%= duration log.start_at, log.end_at %></td>
               <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
             </tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,6 @@
 <% if current_user != @user %>
   <%= back_link "Return to User List", users_path %>
 <% end %>
-<%= back_link "Return to Dashboard", root_path %>
 
 <div class="row">
   <div class="columns">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="columns medium-4">
             <%= label_tag :project_ids, "Projects" %>
-            <%= select_tag :project_ids, options_from_collection_for_select(Project.active, :id, :name), {multiple: true, class: "multiselect"} %>
+            <%= select_tag :project_ids, options_from_collection_for_select(Project.active, :id, :name, params[:project_ids]), {multiple: true, class: "multiselect"} %>
           </div>
           <div class="columns medium-3 small-6">
             <%= label_tag :start_date, "Start Date" %>
@@ -30,37 +30,79 @@
     <div class="spacer"></div>
 
     <h3><%= @user.name %>'s Logs</h3>
+    <% project_ids = params[:project_ids] %>
     <table>
       <thead>
         <tr>
           <th></th>
           <th class="text-left">Log Date</th>
-          <th class="text-left">Start Time</th>
-          <th class="text-left">End Time</th>
+          <% if project_ids.present? %>
+            <th class="text-left">Project</th>
+          <% else %>
+            <th class="text-left">Start Time</th>
+            <th class="text-left">End Time</th>
+          <% end %>
           <th class="text-right">Duration</th>
           <th class="text-center">Edit</th>
         </tr>
       </thead>
       <tbody>
         <% if @logs.present? %>
+          <% total_page_time = 0 %>
+          <% total_time = @user_logs.flat_map(&:project_logs).map{|pl| project_in_user_log?(project_ids, pl) ? pl.hours : 0}.inject(:+) %>
           <% @logs.each do |log| %>
-            <tr>
-              <td class="text-right">
-                <small><%= log_days_of_week(log) %></small>
-              </td>
-              <td class="text-left"><%= link_to log_title(log), log %></td>
-              <td class="text-left"><%= log.start_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
-              <td class="text-left"><%= log.end_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
-              <td class="text-right"><%= duration log.start_at, log.end_at %></td>
-              <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
-            </tr>
+            <% if project_ids.present? %>
+              <% log.project_logs.each do |project_log| %>
+                <% next unless project_in_user_log?(project_ids, project_log) %>
+                <tr>
+                  <td class="text-right">
+                    <small><%= log_days_of_week(log) %></small>
+                  </td>
+                  <td class="text-left"><%= link_to log_title(log), log %></td>
+                  <td class="text-left"><%= project_log.project.name %></td>
+                  <td class="text-right"><%= project_log.hours + "Hours" %></td>
+                  <% total_page_time += project_log.hours %>
+                  <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
+                </tr>
+              <% end %>
+            <% else %>
+              <tr>
+                <td class="text-right">
+                  <small><%= log_days_of_week(log) %></small>
+                </td>
+                <td class="text-left"><%= link_to log_title(log), log %></td>
+                <td class="text-left"><%= log.start_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
+                <td class="text-left"><%= log.end_at.in_time_zone(TIMEZONE).strftime("%-I:%M %p") %></td>
+                <td class="text-right"><%= duration log.start_at, log.end_at %></td>
+                <% total_page_time += duration log.start_at, log.end_at, true %>
+                <td class="text-center"><%= link_to fa_icon("pencil"), edit_log_path(log) %></td>
+              </tr>
+            <% end %>
           <% end %>
         <% else %>
           <tr>
-            <td class="empty" colspan="6">No logs found</td>
+            <% if project_ids.present? %>
+              <td class="empty" colspan="5">No logs found</td>
+            <% else %>
+              <td class="empty" colspan="6">No logs found</td>
+            <% end %>
           </tr>
         <% end %>
       </tbody>
+      <% if project_ids.present? %>
+        <tfoot>
+          <tr>
+            <td class="text-right" colspan="3">Page Total:</td>
+            <td class="text-right" colspan="1"><%= total_page_time %></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td class="text-right stat" colspan="3">Total:</td>
+            <td class="text-right stat" colspan="1"><%= total_time %></td>
+            <td></td>
+          </tr>
+        </tfoot>
+      <% end %>
     </table>
     <%= paginate(@logs, {params: {date: nil}}) if @logs.present? %>
   </div>


### PR DESCRIPTION
I was talking to Connie on Monday, and she mentioned wanting reports for users. We currently allow users to view all of their own logs, with a "jump to date" feature. This just jumps to the page that the date would be on. Admittedly, this is a bit clunky.

Connie wanted employees to be able to filter their logs by date and by project. I think just adding these filters to the "view all logs" page would be fine. I don't think we necessarily need to go making a bunch of reports. Just show them all their logs, with filter options for start date and end date and a multiselect for projects.

Example: I want to know how long I worked and what all I worked on for KETS between Jan. 3 and Jan 8.