### PR TITLE
Invoice Report ordered by user, not project

### DIFF
--- a/app/assets/stylesheets/all/invoice-reports.scss
+++ b/app/assets/stylesheets/all/invoice-reports.scss
@@ -1,0 +1,3 @@
+.invoice-column {
+  width: 20%;
+}

--- a/app/models/reports/invoice_report.rb
+++ b/app/models/reports/invoice_report.rb
@@ -47,17 +47,15 @@ class Reports::InvoiceReport < TablelessModel
     self.end_at = value
   end
 
-  def project_logs(reload=false)
-    return @project_logs if defined?(@project_logs) && !reload
+  def project_logs(project, reload=false)
     return ProjectLog.none if [projects, start_at, end_at].any?(&:blank?)
 
     log_ids       = Log.within(start_at, end_at).pluck(:id)
-    @project_logs = projects.flat_map{|p| p.project_logs.where(log_id: log_ids).includes(:log => :user)}
+    project_logs = ProjectLog.where(log_id: log_ids).where(project: project).includes(:log => :user)
   end
 
-  def grouped_project_logs
-    return project_logs unless project_logs.present?
-    project_logs.group_by { |project_log| project_log.log.user }
+  def grouped_project_logs(project)
+    project_logs(project).group_by { |project_log| project_log.log.user }
   end
 
   private

--- a/app/views/reports/invoice_reports/index.html.erb
+++ b/app/views/reports/invoice_reports/index.html.erb
@@ -3,8 +3,8 @@
 <div class="row">
   <div class="columns">
     <div class="spacer"></div>
-    <h3>Invoice Report for: <%= @invoice_report.projects&.map(&:name)&.to_sentence %></h3>
-    <h5 class="subheader">Period of: <%= @invoice_report.start_date %> - <%= @invoice_report.end_date %></h3>
+    <h2>Invoice Report for: <%= @invoice_report.projects&.map(&:name)&.to_sentence %></h2>
+    <h3 class="subheader">Period of: <%= @invoice_report.start_date %> - <%= @invoice_report.end_date %></h3>
   </div>
 </div>
 
@@ -33,59 +33,50 @@
     </div>
   </div>
 <% end %>
+<br>
 
-<div class="row">
-  <div class="columns">
-    <table class="report invoice-report">
-      <thead>
-        <tr>
-          <th class="text-right">Employee</th>
-          <% if more_than_one_project(@invoice_report) %>
-            <th class="text-right">Project</th>
-          <% end %>
-          <th class="text-right">Date</th>
-          <th class="text-right">Hours</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-
-      <% total = 0 %>
-      <% @invoice_report.grouped_project_logs.each do |user, project_logs| %>
-        <% project_total = project_logs.map(&:hours).inject(:+); total += project_total %>
-        <tbody>
-          <% project_logs.each_with_index do |project_log, index| %>
-            <tr>
-              <% if index == 0 %>
-                <td rowspan="<%= project_logs.size %>" class="text-right"><%= project_log.log.user.name %></td>
-              <% end %>
-              <% if more_than_one_project(@invoice_report) %>
-                <td class="text-right"><%= project_log.project.name %></td>
-              <% end %>
-              <td class="text-right"><%= project_log.log.date %></td>
-              <td class="text-right"><%= project_log.hours %></td>
-              <td><%= simple_format project_log.description %></td>
-            </tr>
-          <% end %>
-          <tr class="subtotal">
-            <% if more_than_one_project(@invoice_report) %>
-              <td></td>
+<% @invoice_report.projects.each do |project| %>
+  <% total = 0 %>
+  <div class="row">
+    <div class="columns">
+      <h4><%= project.name %></h4>
+      <table class="report invoice-report">
+        <thead>
+          <tr>
+            <th class="text-right" style="width: 20%;">Employee</th>
+            <th class="text-right" style="width: 20%;">Date</th>
+            <th class="text-right" style="width: 20%;">Hours</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <% @invoice_report.grouped_project_logs(project).each do |user, project_logs| %>
+          <tbody>
+            <% user_total = project_logs.map(&:hours).inject(:+); total += user_total %>
+            <% project_logs.each do |project_log| %>
+              <tr>
+                <% if project_log == project_logs.first %>
+                  <td rowspan="<%= project_logs.size %>" class="text-right"><%= user.name %></td>
+                <% end %>
+                <td class="text-right"><%= project_log.log.date %></td>
+                <td class="text-right"><%= project_log.hours %></td>
+                <td><%= simple_format project_log.description %></td>
+              </tr>
             <% end %>
-            <td class="text-right" colspan="2">Subtotal:</td>
-            <td class="text-right"><%= project_total %></td>
+            <tr class="subtotal">
+              <td class="text-right" colspan="2">Subtotal:</td>
+              <td class="text-right"><b><%= user_total %></b></td>
+              <td></td>
+            </tr>
+          </tbody>
+        <% end %>
+        <tfoot>
+          <tr>
+            <td class="text-right stat" colspan="2">Total:</td>
+            <td class="text-right stat"><%= total %></td>
             <td></td>
           </tr>
-        </tbody>
-      <% end %>
-      <tfoot>
-        <tr>
-          <% if more_than_one_project(@invoice_report) %>
-            <td></td>
-          <% end %>
-          <td class="text-right stat" colspan="2">Total:</td>
-          <td class="text-right stat"><%= total %></td>
-          <td></td>
-        </tr>
-      </tfoot>
-    </table>
+        </tfoot>
+      </table>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/reports/invoice_reports/index.html.erb
+++ b/app/views/reports/invoice_reports/index.html.erb
@@ -43,9 +43,9 @@
       <table class="report invoice-report">
         <thead>
           <tr>
-            <th class="text-right" style="width: 20%;">Employee</th>
-            <th class="text-right" style="width: 20%;">Date</th>
-            <th class="text-right" style="width: 20%;">Hours</th>
+            <th class="text-right invoice-column">Employee</th>
+            <th class="text-right invoice-column">Date</th>
+            <th class="text-right invoice-column">Hours</th>
             <th>Description</th>
           </tr>
         </thead>


### PR DESCRIPTION
My understanding of the invoice report was that you would input which projects you are filtering from, then see logs sorted by project first, then individual users within that.

It's generally fine right now if you only select one project. But if you select multiple projects, it gives something like: "Invoice Report for Project 1 and 2", then the table goes by user first and orders by project within that. The end of the table shows the total hours for all users for each project chosen.
<img width="934" alt="Screen Shot 2020-01-24 at 11 16 27 AM" src="https://user-images.githubusercontent.com/26553688/73089002-ff758900-3e9a-11ea-9315-55d6b6e0bb27.png">
