### PR TITLE
Add button to save and start a new log (starting with previous ending time)

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -24,7 +24,14 @@ class LogsController < ApplicationController
   def update
     respond_to do |format|
       if @log.update_attributes(log_params)
-        format.html { redirect_to @log, notice: "Successfully updated log" }
+        if params[:commit] == "Save and Start a New Log"
+          load_new_log
+          if @log.save
+            format.html { redirect_to edit_log_path(@log), notice: "Successfully updated log" }
+          end
+        else
+          format.html { redirect_to @log, notice: "Successfully updated log" }
+        end
       else
         @log.project_logs.build if @log.project_logs.blank?
 

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -57,12 +57,18 @@ class LogsController < ApplicationController
     def load_new_log
       start_at = DateTime.now
 
-      if params[:continue] && ToBoolean(params[:continue])
+      if continuing?
         last_log = current_user.logs.order('end_at DESC').first
         start_at = last_log.end_at + 1.second if last_log
       end
 
       @log = Log.new(user: current_user, start_at: start_at)
+    end
+
+    def continuing?
+      if (params[:continue] && ToBoolean(params[:continue])) || params[:commit] == "Save and Start a New Log"
+        return true
+      end
     end
 
     def log_params

--- a/app/views/layouts/_current_log.html.erb
+++ b/app/views/layouts/_current_log.html.erb
@@ -1,21 +1,23 @@
 <div class="current-log">
   <div class="row">
     <div class="columns">
-      <%= link_to fa_icon("clock-o", text: "Finish Current Log"), edit_log_path(current_log) %>
-      <%= content_tag :div, nil, id: 'elapsed-time',
-                                 style: 'display: inline-block;',
-                                 title: 'Elapsed Time',
-                                 data: {
-                                   start_date: current_log.start_at.in_time_zone(TIMEZONE).to_s,
-                                   tooltip: ''
-                                 } %>
+      <% unless url_for.to_s.match(/\/logs\/\d+\/edit/) %>
+        <%= link_to fa_icon("clock-o", text: "Finish Current Log"), edit_log_path(current_log) %>
+        <%= content_tag :div, nil, id: 'elapsed-time',
+                                   style: 'display: inline-block;',
+                                   title: 'Elapsed Time',
+                                   data: {
+                                     start_date: current_log.start_at.in_time_zone(TIMEZONE).to_s,
+                                     tooltip: ''
+                                   } %>
+      <% end %>
     </div>
   </div>
 </div>
-
+<!-- current_log.start_at needs to be LESS than 24.hours.ago because those both return a DATE, not elapsed time -->
 <script>
 var $el   = $('#elapsed-time'),
     start = moment($el.data('start-date')).toDate();
 
-$el.countdown({since: start, layout: '<b>{hnn}h {mnn}m {snn}s</b>'});
+$el.countdown({since: start, layout: '<b> <% if current_log.start_at < 24.hours.ago %>{dnn}d<% end %> {hnn}h {mnn}m {snn}s</b>'});
 </script>

--- a/app/views/logs/_form.html.erb
+++ b/app/views/logs/_form.html.erb
@@ -51,6 +51,12 @@
       <%= f.submit "Save Log", class: 'button success expanded' %>
     </div>
   </div>
+
+  <div class="row">
+    <div class="columns">
+      <%= f.submit "Save and Start a New Log", class: 'button success expanded hollow' %>
+    </div>
+  </div>
 <% end %>
 
 <% unless @log.activated? %>

--- a/app/views/logs/_form.html.erb
+++ b/app/views/logs/_form.html.erb
@@ -48,13 +48,13 @@
 
   <div class="row">
     <div class="columns">
-      <%= f.submit "Save Log", class: 'button success expanded' %>
+      <%= f.submit "Save and Start a New Log", class: 'button success expanded hollow' %>
     </div>
   </div>
 
   <div class="row">
     <div class="columns">
-      <%= f.submit "Save and Start a New Log", class: 'button success expanded hollow' %>
+      <%= f.submit "Save Log", class: 'button success expanded' %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
From Connie:
On the bottom of the edit log page, could you make it so there's one button to save (and can it/does it automatically save without clicking the save button?) and a different button that would automatically start a new record from that end time without having to go back to the list?  Ideally, one click would stop the time and start a new record.

On the save/start new button, wanted to make sure I was clear that I want to keep a button like you have now, but this would be a new button with the option of going straight to a new log entry that has already been started.  In other words, don't delete the current functionality, this would just be a new button. 