### PR TITLE
Error when clicking Save and Start New Log with no End Date

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -25,9 +25,12 @@ class LogsController < ApplicationController
     respond_to do |format|
       if @log.update_attributes(log_params)
         if params[:commit] == "Save and Start a New Log"
-          load_new_log
-          if @log.save
-            format.html { redirect_to edit_log_path(@log), notice: "Successfully updated log" }
+          if load_new_log
+            if @log.save
+              format.html { redirect_to edit_log_path(@log), notice: "Successfully updated log" }
+            end
+          else
+            format.html { redirect_to @log, alert: "Cannot start a new log until this log is finished" }
           end
         else
           format.html { redirect_to @log, notice: "Successfully updated log" }
@@ -59,7 +62,11 @@ class LogsController < ApplicationController
 
       if continuing?
         last_log = current_user.logs.order('end_at DESC').first
-        start_at = last_log.end_at + 1.second if last_log
+        if last_log.end_at?
+          start_at = last_log.end_at + 1.second if last_log
+        else
+          return false
+        end
       end
 
       @log = Log.new(user: current_user, start_at: start_at)


### PR DESCRIPTION
I noticed that if you click Save and Start New Log without an End Date, then it causes an error because it's trying to create a new log with the old end date which is non-existent. Might be a good idea to hide it and have js check if there is an End Date and then show it