### PR TITLE
Graph doesn't appear when using back button

### DIFF
--- a/app/assets/javascripts/dashboard.coffee
+++ b/app/assets/javascripts/dashboard.coffee
@@ -36,7 +36,13 @@ class Dashboard
     numAnim = new CountUp stat, startVal, endVal, decimals
     numAnim.start()
 
-$(document).on 'dashboard_index.load', (e, obj) =>
+ready= ->
   dashboard = new Dashboard
   dashboard.hoursChart()
   dashboard.weekHoursCount()
+
+$(document).on 'dashboard_index.load', (e, obj) =>
+  ready()
+
+$(document).on 'turbolinks:load', (e, obj) =>
+  ready()

--- a/app/assets/javascripts/dashboard.coffee
+++ b/app/assets/javascripts/dashboard.coffee
@@ -45,4 +45,5 @@ $(document).on 'dashboard_index.load', (e, obj) =>
   ready()
 
 $(document).on 'turbolinks:load', (e, obj) =>
-  ready()
+  if window.location.pathname == '/' #dashboard
+    ready()


### PR DESCRIPTION
This is a tiny issue, but when I go to a page, then click the browser's back button to the dashboard, the graph doesn't appear and you have to refresh the page to see it. Don't know if it's possible to fix, but might be helpful