### PR TITLE
Default Sort Order for Personal Reports to Descending

### DIFF
--- a/app/models/reports/personal_report.rb
+++ b/app/models/reports/personal_report.rb
@@ -55,7 +55,11 @@ class Reports::PersonalReport < TablelessModel
   def grouped_logs(user)
     return logs unless logs.present?
     group_logs = logs.reject{|l| l.user != user}.group_by(&:date)
-    group_logs = group_logs.to_a.reverse.to_h if sort_date == "desc"
+    
+    if sort_date.nil? || sort_date == "desc"
+      group_logs = group_logs.to_a.reverse.to_h
+    end
+
     group_logs
   end
 

--- a/app/views/reports/personal_reports/_form.html.erb
+++ b/app/views/reports/personal_reports/_form.html.erb
@@ -22,7 +22,7 @@
 
     <div class="columns medium-3">
       <%= label_tag :sort_date, "Sort Date" %>
-      <%= f.select :sort_date, {"Ascending" => "asc", "Descending" => "desc"} %>
+      <%= f.select :sort_date, {"Descending" => "desc", "Ascending" => "asc"} %>
     </div>
 
     <div class="columns medium-3">


### PR DESCRIPTION
Connie requested to change the default sort order of the personal reports to be sorted by date in descending order.